### PR TITLE
Ocultar menú hasta login y añadir perfil de usuario

### DIFF
--- a/Components/Layout/MainLayout.razor
+++ b/Components/Layout/MainLayout.razor
@@ -1,9 +1,13 @@
 ﻿@inherits LayoutComponentBase
+@inject TP3MovilFullstack.Services.UserService UserService
 
 <div class="page">
-    <div class="sidebar">
-        <NavMenu />
-    </div>
+    @if (UserService.CurrentUser != null)
+    {
+        <div class="sidebar">
+            <NavMenu />
+        </div>
+    }
 
     <main>
         <div class="top-row px-4">

--- a/Components/Layout/NavMenu.razor
+++ b/Components/Layout/NavMenu.razor
@@ -1,4 +1,6 @@
-﻿<div class="top-row ps-3 navbar navbar-dark">
+﻿@inject TP3MovilFullstack.Services.UserService UserService
+
+<div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
         <a class="navbar-brand" href="">TP3MovilFullstack</a>
     </div>
@@ -9,18 +11,13 @@
 <div class="nav-scrollable" onclick="document.querySelector('.navbar-toggler').click()">
     <nav class="flex-column">
         <div class="nav-item px-3">
-            <NavLink class="nav-link" href="Login">
-                <span class="bi bi-box-arrow-in-right" aria-hidden="true"></span> Login
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="Registro">
-                <span class="bi bi-box-arrow-in-right" aria-hidden="true"></span> Registro
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
             <NavLink class="nav-link" href="peliculas">
                 <span class="bi bi-film" aria-hidden="true"></span> Listado Películas
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="perfil">
+                <span class="bi bi-person" aria-hidden="true"></span> Perfil
             </NavLink>
         </div>
     </nav>

--- a/Components/Pages/Home.razor
+++ b/Components/Pages/Home.razor
@@ -1,5 +1,9 @@
 ﻿@page "/"
+@inject NavigationManager Navigation
 
-<h1>Hello, world!</h1>
-
-Welcome to your new app.
+@code {
+    protected override void OnInitialized()
+    {
+        Navigation.NavigateTo("/login", true);
+    }
+}

--- a/Components/Pages/Login.razor
+++ b/Components/Pages/Login.razor
@@ -45,8 +45,8 @@
         var user = UserService.ValidateLogin(loginModel.Email, loginModel.Password);
         if (user != null)
         {
-            // Redirigir a la página de usuario o dashboard
-            Navigation.NavigateTo("/userpage");
+            // Redirigir al listado de películas
+            Navigation.NavigateTo("/peliculas");
         }
         else
         {

--- a/Components/Pages/Perfil.razor
+++ b/Components/Pages/Perfil.razor
@@ -1,0 +1,69 @@
+@page "/perfil"
+@using System.ComponentModel.DataAnnotations
+@using TP3MovilFullstack.Models
+@inject TP3MovilFullstack.Services.UserService UserService
+
+<PageTitle>Perfil</PageTitle>
+
+<h3>Perfil de Usuario</h3>
+
+@if (usuario == null)
+{
+    <p>No hay un usuario autenticado.</p>
+}
+else
+{
+    <EditForm Model="usuario" OnValidSubmit="Guardar">
+        <DataAnnotationsValidator />
+        <ValidationSummary />
+        <div class="mb-3">
+            <label class="form-label">Nombre</label>
+            <InputText class="form-control" @bind-Value="usuario.Nombre" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Correo Electrónico</label>
+            <InputText type="email" class="form-control" @bind-Value="usuario.Email" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Contraseña</label>
+            <InputText type="password" class="form-control" @bind-Value="usuario.Password" />
+        </div>
+        <button type="submit" class="btn btn-primary">Guardar</button>
+    </EditForm>
+    @if (!string.IsNullOrEmpty(mensaje))
+    {
+        <div class="alert alert-success mt-3">@mensaje</div>
+    }
+}
+
+@code {
+    private Usuario? usuario;
+    private string? mensaje;
+
+    protected override void OnInitialized()
+    {
+        var current = UserService.CurrentUser;
+        if (current != null)
+        {
+            usuario = new Usuario
+            {
+                Id = current.Id,
+                Nombre = current.Nombre,
+                Email = current.Email,
+                Password = current.Password,
+                Rol = current.Rol,
+                ImagenPath = current.ImagenPath,
+                ImagenDataUrl = current.ImagenDataUrl
+            };
+        }
+    }
+
+    private void Guardar()
+    {
+        if (usuario != null)
+        {
+            UserService.UpdateUser(usuario);
+            mensaje = "Datos actualizados";
+        }
+    }
+}

--- a/Components/Pages/Userpage.razor
+++ b/Components/Pages/Userpage.razor
@@ -1,9 +1,0 @@
-﻿@page "/userpage"
-
-<h3>Userpage</h3>
-
-
-
-@code {
-
-}

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -8,6 +8,8 @@ namespace TP3MovilFullstack.Services
         private readonly List<Usuario> _usuarios;
         private const string UsersFileName = "usuarios.json";
 
+        public Usuario? CurrentUser { get; private set; }
+
         public UserService()
         {
             _usuarios = new List<Usuario>();
@@ -30,9 +32,30 @@ namespace TP3MovilFullstack.Services
 
         public Usuario? ValidateLogin(string email, string password)
         {
-            return _usuarios.FirstOrDefault(u =>
+            var user = _usuarios.FirstOrDefault(u =>
                 u.Email?.Equals(email, StringComparison.OrdinalIgnoreCase) == true &&
                 u.Password == password);
+
+            if (user != null)
+            {
+                CurrentUser = user;
+            }
+
+            return user;
+        }
+
+        public void UpdateUser(Usuario updatedUser)
+        {
+            var index = _usuarios.FindIndex(u => u.Id == updatedUser.Id);
+            if (index != -1)
+            {
+                _usuarios[index] = updatedUser;
+                SaveChanges();
+                if (CurrentUser?.Id == updatedUser.Id)
+                {
+                    CurrentUser = updatedUser;
+                }
+            }
         }
 
         private void SaveChanges()


### PR DESCRIPTION
## Summary
- Ocultar la barra lateral hasta que un usuario inicie sesión
- Añadir enlace a perfil de usuario con formulario de edición
- Redirigir al listado de películas tras iniciar sesión

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689e5d24cfd88329920cd5e5c5cebe70