### PR TITLE
Add usuarios listing and editing

### DIFF
--- a/Components/Layout/NavMenu.razor
+++ b/Components/Layout/NavMenu.razor
@@ -16,6 +16,11 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="usuarios">
+                <span class="bi bi-people" aria-hidden="true"></span> Usuarios
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="perfil">
                 <span class="bi bi-person" aria-hidden="true"></span> Perfil
             </NavLink>

--- a/Components/Pages/Perfil.razor
+++ b/Components/Pages/Perfil.razor
@@ -1,6 +1,8 @@
 @page "/perfil"
+@page "/perfil/{id:int}"
 @using System.ComponentModel.DataAnnotations
 @using TP3MovilFullstack.Models
+@using Microsoft.AspNetCore.Components
 @inject TP3MovilFullstack.Services.UserService UserService
 
 <PageTitle>Perfil</PageTitle>
@@ -9,7 +11,7 @@
 
 @if (usuario == null)
 {
-    <p>No hay un usuario autenticado.</p>
+    <p>No hay un usuario seleccionado.</p>
 }
 else
 {
@@ -37,12 +39,21 @@ else
 }
 
 @code {
+    [Parameter] public int? Id { get; set; }
     private Usuario? usuario;
     private string? mensaje;
 
     protected override void OnInitialized()
     {
-        var current = UserService.CurrentUser;
+        Usuario? current = null;
+        if (Id.HasValue)
+        {
+            current = UserService.GetUsuario(Id.Value);
+        }
+        else
+        {
+            current = UserService.CurrentUser;
+        }
         if (current != null)
         {
             usuario = new Usuario

--- a/Components/Pages/Usuarios.razor
+++ b/Components/Pages/Usuarios.razor
@@ -1,0 +1,71 @@
+@page "/usuarios"
+@using TP3MovilFullstack.Models
+@inject TP3MovilFullstack.Services.UserService UserService
+@inject NavigationManager navigationManager
+
+<PageTitle>Usuarios</PageTitle>
+
+<h3>Listado de Usuarios</h3>
+
+@if (usuarios == null || !usuarios.Any())
+{
+    <p>No hay usuarios registrados.</p>
+}
+else
+{
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Imagen</th>
+                <th>Nombre</th>
+                <th>Email</th>
+                <th>Rol</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var usuario in usuarios)
+            {
+                <tr>
+                    <td>
+                        @if (!string.IsNullOrWhiteSpace(usuario.ImagenPath))
+                        {
+                            <img src="@usuario.ImagenPath" alt="Imagen de @usuario.Nombre" style="width:50px;height:50px;object-fit:cover;" />
+                        }
+                    </td>
+                    <td>@usuario.Nombre</td>
+                    <td>@usuario.Email</td>
+                    <td>@usuario.Rol</td>
+                    <td>
+                        <button class="btn btn-sm btn-primary me-2" @onclick="() => EditarUsuario(usuario.Id)">
+                            <i class="bi bi-pencil"></i>
+                        </button>
+                        <button class="btn btn-sm btn-danger" @onclick="() => EliminarUsuario(usuario.Id)">
+                            <i class="bi bi-trash"></i>
+                        </button>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+@code {
+    private List<Usuario> usuarios = new();
+
+    protected override void OnInitialized()
+    {
+        usuarios = UserService.GetAll();
+    }
+
+    private void EditarUsuario(int id)
+    {
+        navigationManager.NavigateTo($"/perfil/{id}");
+    }
+
+    private void EliminarUsuario(int id)
+    {
+        UserService.DeleteUser(id);
+        usuarios = UserService.GetAll();
+    }
+}

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -58,6 +58,20 @@ namespace TP3MovilFullstack.Services
             }
         }
 
+        public void DeleteUser(int id)
+        {
+            var user = _usuarios.FirstOrDefault(u => u.Id == id);
+            if (user != null)
+            {
+                _usuarios.Remove(user);
+                SaveChanges();
+                if (CurrentUser?.Id == id)
+                {
+                    CurrentUser = null;
+                }
+            }
+        }
+
         private void SaveChanges()
         {
             var filePath = GetFilePath();


### PR DESCRIPTION
## Summary
- Add Usuarios.razor to list all users with edit and delete actions
- Allow Perfil.razor to edit any user via optional id parameter
- Support user deletion in UserService and add nav menu link

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e94f5c4388329ba4c86243c707470