### PR TITLE
Handle image paths with data URLs

### DIFF
--- a/Components/Pages/AgregarPelicula.razor
+++ b/Components/Pages/AgregarPelicula.razor
@@ -2,6 +2,7 @@
 @using Microsoft.Maui.Storage
 @using TP3MovilFullstack.Models
 @using TP3MovilFullstack.Services
+@using TP3MovilFullstack.Utils
 @inject NavigationManager navigationManager
 @inject PeliculaService peliculaService
 @inject TP3MovilFullstack.Services.UserService UserService
@@ -66,9 +67,9 @@
                                 <div class="mb-3">
                                     <label class="form-label">Vista previa:</label>
                                     <div class="border rounded p-2 d-flex align-items-center justify-content-center" style="height: 250px; background-color: #f8f9fa;">
-                                        @if (!string.IsNullOrWhiteSpace(pelicula.ImagenPath))
+                                        @if (!string.IsNullOrWhiteSpace(pelicula.ImagenDataUrl))
                                         {
-                                            <img src="@pelicula.ImagenPath"
+                                            <img src="@pelicula.ImagenDataUrl"
                                                  alt="Vista previa de la imagen"
                                                  class="img-fluid rounded"
                                                  style="max-height: 100%; max-width: 100%; object-fit: cover;" />
@@ -139,8 +140,10 @@
                 await using FileStream fs = new(filePath, FileMode.Create);
                 await selectedFile.OpenReadStream(maxAllowedSize: 5120000).CopyToAsync(fs); // Límite de 5MB
 
-                // Guardar la ruta completa del archivo para poder leerlo después
+                // Guardar la ruta completa del archivo y datos asociados
                 pelicula.ImagenPath = filePath;
+                pelicula.ImagenContentType = selectedFile.ContentType;
+                pelicula.ImagenDataUrl = ImageHelper.ToDataUrl(filePath);
             }
 
             peliculaService.AddPelicula(pelicula);
@@ -159,9 +162,10 @@
         {
             // Para la vista previa, creamos una URL de datos (Base64)
             var buffer = new byte[selectedFile.Size];
-            await selectedFile.OpenReadStream().ReadAsync(buffer);
+            await selectedFile.OpenReadStream(maxAllowedSize: 5120000).ReadAsync(buffer);
             var base64 = Convert.ToBase64String(buffer);
-            pelicula.ImagenPath = $"data:{selectedFile.ContentType};base64,{base64}";
+            pelicula.ImagenContentType = selectedFile.ContentType;
+            pelicula.ImagenDataUrl = $"data:{selectedFile.ContentType};base64,{base64}";
         }
         StateHasChanged();
     }

--- a/Components/Pages/DetallePelicula.razor
+++ b/Components/Pages/DetallePelicula.razor
@@ -49,11 +49,11 @@ else
                 <div class="card shadow">
                     <div class="card-body p-0">
                         <div class="d-flex align-items-center justify-content-center" style="height: 400px; background-color: #f8f9fa;">
-                            @if (!string.IsNullOrWhiteSpace(pelicula.ImagenPath))
+                            @if (!string.IsNullOrWhiteSpace(pelicula.ImagenDataUrl))
                             {
-                                <img src="@pelicula.ImagenPath" 
-                                     alt="Póster de @pelicula.Titulo" 
-                                     class="img-fluid rounded" 
+                                <img src="@pelicula.ImagenDataUrl"
+                                     alt="Póster de @pelicula.Titulo"
+                                     class="img-fluid rounded"
                                      style="max-height: 100%; max-width: 100%; object-fit: cover;"
                                      onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';" />
                                 <div class="text-center text-muted" style="display: none;">

--- a/Components/Pages/EditarPelicula.razor
+++ b/Components/Pages/EditarPelicula.razor
@@ -96,9 +96,9 @@ else
                                     <div class="mb-3">
                                         <label class="form-label">Vista previa actual:</label>
                                         <div class="border rounded p-2 d-flex align-items-center justify-content-center" style="height: 250px; background-color: #f8f9fa;">
-                                            @if (!string.IsNullOrWhiteSpace(pelicula.ImagenPath))
+                                            @if (!string.IsNullOrWhiteSpace(pelicula.ImagenDataUrl))
                                             {
-                                                <img src="@pelicula.ImagenPath"
+                                                <img src="@pelicula.ImagenDataUrl"
                                                      alt="Vista previa de @pelicula.Titulo"
                                                      class="img-fluid rounded"
                                                      style="max-height: 100%; max-width: 100%; object-fit: cover;"
@@ -175,7 +175,8 @@ else
                 Titulo = peliculaEncontrada.Titulo,
                 Anio = peliculaEncontrada.Anio,
                 Director = peliculaEncontrada.Director,
-                ImagenPath = peliculaEncontrada.ImagenPath
+                ImagenPath = peliculaEncontrada.ImagenPath,
+                ImagenDataUrl = peliculaEncontrada.ImagenDataUrl
             };
 
             // Creamos una copia para editar
@@ -185,7 +186,8 @@ else
                 Titulo = peliculaEncontrada.Titulo,
                 Anio = peliculaEncontrada.Anio,
                 Director = peliculaEncontrada.Director,
-                ImagenPath = peliculaEncontrada.ImagenPath
+                ImagenPath = peliculaEncontrada.ImagenPath,
+                ImagenDataUrl = peliculaEncontrada.ImagenDataUrl
             };
         }
     }
@@ -229,6 +231,7 @@ else
             pelicula.Anio = peliculaOriginal.Anio;
             pelicula.Director = peliculaOriginal.Director;
             pelicula.ImagenPath = peliculaOriginal.ImagenPath;
+            pelicula.ImagenDataUrl = peliculaOriginal.ImagenDataUrl;
             StateHasChanged(); // Forzar actualización de la UI
         }
     }

--- a/Components/Pages/ListadoPeliculas.razor
+++ b/Components/Pages/ListadoPeliculas.razor
@@ -47,9 +47,9 @@
                 <div class="col">
                     <div class="card h-100 shadow-sm">
                         <div class="d-flex align-items-center justify-content-center bg-light" style="height: 250px;">
-                            @if (!string.IsNullOrWhiteSpace(pelicula.ImagenPath))
+                            @if (!string.IsNullOrWhiteSpace(pelicula.ImagenDataUrl))
                             {
-                                <img src="@pelicula.ImagenPath"
+                                <img src="@pelicula.ImagenDataUrl"
                                      alt="Póster de @pelicula.Titulo"
                                      class="img-fluid rounded-top"
                                      style="max-height: 100%; max-width: 100%; object-fit: cover;"

--- a/Components/Pages/Usuarios.razor
+++ b/Components/Pages/Usuarios.razor
@@ -26,9 +26,9 @@ else
             {
                 <tr>
                     <td>
-                        @if (!string.IsNullOrWhiteSpace(usuario.ImagenPath))
+                        @if (!string.IsNullOrWhiteSpace(usuario.ImagenDataUrl))
                         {
-                            <img src="@usuario.ImagenPath" alt="Imagen de @usuario.Nombre" style="width:50px;height:50px;object-fit:cover;" />
+                            <img src="@usuario.ImagenDataUrl" alt="Imagen de @usuario.Nombre" style="width:50px;height:50px;object-fit:cover;" />
                         }
                     </td>
                     <td>@usuario.Nombre</td>

--- a/Services/PeliculaService.cs
+++ b/Services/PeliculaService.cs
@@ -1,5 +1,6 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using TP3MovilFullstack.Models;
+using TP3MovilFullstack.Utils;
 
 namespace TP3MovilFullstack.Services
 {
@@ -31,6 +32,7 @@ namespace TP3MovilFullstack.Services
         public void AddPelicula(Pelicula pelicula)
         {
             pelicula.Id = _peliculas.Any() ? _peliculas.Max(p => p.Id) + 1 : 1;
+            pelicula.ImagenDataUrl = ImageHelper.ToDataUrl(pelicula.ImagenPath);
             _peliculas.Add(pelicula);
             SavePeliculasToJsonFile();
         }
@@ -49,6 +51,7 @@ namespace TP3MovilFullstack.Services
                 {
                     peliculaExistente.ImagenPath = pelicula.ImagenPath;
                     peliculaExistente.ImagenContentType = pelicula.ImagenContentType;
+                    peliculaExistente.ImagenDataUrl = ImageHelper.ToDataUrl(pelicula.ImagenPath);
                 }
             }
             SavePeliculasToJsonFile();
@@ -94,6 +97,10 @@ namespace TP3MovilFullstack.Services
                 {
                     _peliculas.Clear();
                     _peliculas.AddRange(peliculasFromFile);
+                    foreach (var p in _peliculas)
+                    {
+                        p.ImagenDataUrl = ImageHelper.ToDataUrl(p.ImagenPath);
+                    }
                 }
             }
         }

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -1,5 +1,6 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using TP3MovilFullstack.Models;
+using TP3MovilFullstack.Utils;
 
 namespace TP3MovilFullstack.Services
 {
@@ -29,7 +30,8 @@ namespace TP3MovilFullstack.Services
                     Email = "admin@admin.com",
                     Password = "admin",
                     Rol = "admin",
-                    ImagenPath = adminImage
+                    ImagenPath = adminImage,
+                    ImagenDataUrl = ImageHelper.ToDataUrl(adminImage)
                 });
                 _usuarios.Add(new Usuario
                 {
@@ -38,7 +40,8 @@ namespace TP3MovilFullstack.Services
                     Email = "user@user.com",
                     Password = "user",
                     Rol = "user",
-                    ImagenPath = userImage
+                    ImagenPath = userImage,
+                    ImagenDataUrl = ImageHelper.ToDataUrl(userImage)
                 });
                 SaveChanges();
             }
@@ -72,6 +75,7 @@ namespace TP3MovilFullstack.Services
         public void AddUser(Usuario newUser)
         {
             newUser.Id = _usuarios.Any() ? _usuarios.Max(u => u.Id) + 1 : 1;
+            newUser.ImagenDataUrl = ImageHelper.ToDataUrl(newUser.ImagenPath);
             _usuarios.Add(newUser);
             SaveChanges();
         }
@@ -81,6 +85,7 @@ namespace TP3MovilFullstack.Services
             var index = _usuarios.FindIndex(u => u.Id == updatedUser.Id);
             if (index != -1)
             {
+                updatedUser.ImagenDataUrl = ImageHelper.ToDataUrl(updatedUser.ImagenPath);
                 _usuarios[index] = updatedUser;
                 SaveChanges();
                 if (CurrentUser?.Id == updatedUser.Id)
@@ -122,6 +127,10 @@ namespace TP3MovilFullstack.Services
                 {
                     _usuarios.Clear();
                     _usuarios.AddRange(users);
+                    foreach (var u in _usuarios)
+                    {
+                        u.ImagenDataUrl = ImageHelper.ToDataUrl(u.ImagenPath);
+                    }
                 }
             }
         }

--- a/Utils/ImageHelper.cs
+++ b/Utils/ImageHelper.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using Microsoft.Maui.Storage;
+
+namespace TP3MovilFullstack.Utils
+{
+    public static class ImageHelper
+    {
+        public static string ToDataUrl(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return Fallback();
+            }
+
+            string fullPath = ResolvePath(path);
+            if (!File.Exists(fullPath))
+            {
+                return Fallback();
+            }
+
+            try
+            {
+                byte[] bytes = File.ReadAllBytes(fullPath);
+                string contentType = GetContentType(fullPath);
+                string base64 = Convert.ToBase64String(bytes);
+                return $"data:{contentType};base64,{base64}";
+            }
+            catch
+            {
+                return Fallback();
+            }
+        }
+
+        private static string ResolvePath(string path)
+        {
+            if (Path.IsPathRooted(path))
+            {
+                return path;
+            }
+
+            // Check in AppDataDirectory
+            var appData = Path.Combine(FileSystem.AppDataDirectory, path);
+            if (File.Exists(appData))
+            {
+                return appData;
+            }
+
+            // Check in AppPackageDirectory
+            var appPackage = Path.Combine(FileSystem.AppPackageDirectory, path);
+            if (File.Exists(appPackage))
+            {
+                return appPackage;
+            }
+
+            return path; // return original, will fail later
+        }
+
+        private static string GetContentType(string path)
+        {
+            return Path.GetExtension(path).ToLowerInvariant() switch
+            {
+                ".jpg" or ".jpeg" => "image/jpeg",
+                ".png" => "image/png",
+                ".gif" => "image/gif",
+                ".svg" => "image/svg+xml",
+                _ => "application/octet-stream"
+            };
+        }
+
+        private static string Fallback()
+        {
+            // 1x1 transparent GIF
+            return "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add ImageHelper utility for converting image paths to data URLs with fallback
- generate and store image data URLs in PeliculaService and UserService
- show image previews via data URLs and fix AgregarPelicula form

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a5df683ddc8329b1dc013747456c64